### PR TITLE
Increase readFile timeout to infinite in an attempt to workaround filesystem issues

### DIFF
--- a/wdl/transforms/new-base/src/main/scala/wdl/transforms/base/linking/expression/values/EngineFunctionEvaluators.scala
+++ b/wdl/transforms/new-base/src/main/scala/wdl/transforms/base/linking/expression/values/EngineFunctionEvaluators.scala
@@ -50,7 +50,7 @@ object EngineFunctionEvaluators {
       EvaluatedValue(WomSingleFile(ioFunctionSet.pathFunctions.stderr), Seq.empty).validNel
   }
 
-  private val ReadWaitTimeout = 10.minutes
+  private val ReadWaitTimeout = Duration.Inf
   private def readFile(fileToRead: WomSingleFile, ioFunctionSet: IoFunctionSet, sizeLimit: Int) =
     Try(
       Await.result(ioFunctionSet.readFile(fileToRead.value, Option(sizeLimit), failOnOverflow = true), ReadWaitTimeout)


### PR DESCRIPTION
Many other operations within Cromwell have an infinite duration, so this is not that out of a place change.

See: https://jira.oicr.on.ca/browse/GP-4716